### PR TITLE
Bump open-snippet lib version from 0.8.1 to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@oclif/plugin-help": "^3",
     "js-yaml": "^3.14.0",
     "lodash": "^4.17.15",
-    "openapi-snippet": "^0.8.1",
+    "openapi-snippet": "^0.11.0",
     "openapi-types": "^1.3.5",
     "swagger-parser": "^9.0.1",
     "tslib": "^1"


### PR DESCRIPTION
Hi @richardkabiling 

I contributed to the `ErikWittern/openapi-snippet` latest release (https://github.com/ErikWittern/openapi-snippet/releases/tag/v0.11.0) and I'm here to ask you if you please could bump the `openapi-snippet` version on your project.

Let me know if I can help you with anything else.

Thank you in advance 🍻 